### PR TITLE
Add 404 detection in responseURL, other improvements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "author": "damufo",
-  "version": "2.0.0",
+  "version": "2.0.1",
 
   "homepage_url": "https://github.com/damufo/link-analyzer",
 


### PR DESCRIPTION
* Add 404 detection in responseURL
* Add status in tooltip
* Fix null check on additional (null check didn't work)
* Add semicolons after styleSup
* getHeight and getWidth didn't do a good job, cleanup and improve
=> getHeight didn't work with scrollable surfaces - tested on Linux, getWidth had probably the same problem. clientHeight is currently visible area, not possibly visible area
* -moz-border-radius was deprecated, it's now simply border-radius
* Fix typo
* Add TODO about 302 redirects
* Increase version to 2.0.1