### PR TITLE
Fix bug and more

### DIFF
--- a/content/content-script.js
+++ b/content/content-script.js
@@ -204,7 +204,8 @@ linkAnalyzer = {
 		
 		// add this to it's appropriate statistic array
 		linkAnalyzer.statistics[r].push(el);
-		linkAnalyzer.attr(el, "title", "This link was marked as \"" + r + "\"" + " (code " + status + ")");
+		let codeText = status != null ? " (code " + status + ")" : "";
+		linkAnalyzer.attr(el, "title", "This link was marked as \"" + r.replace("link", "").toLowerCase() + "\"" + codeText);
 		
 		// and last, let's check if we didn't check all links already
 		var temp = linkAnalyzer.statistics.linkFine.length + 
@@ -321,7 +322,7 @@ linkAnalyzer = {
 				}
 
 				// Extras
-				response = xml.responseURL.includes("404") ? "linkBroken" : response;
+				response = xml.responseURL.includes("404") && !xml.url.includes("404") ? "linkBroken" : response;
 
 				// now let's color link according to this response
 				linkAnalyzer.handler (response, el, xml.status);
@@ -333,8 +334,8 @@ linkAnalyzer = {
     	};
 		
 		xml.open("HEAD", url, true);
-		//xml.send(null);
 		xml.withCredentials = true; 
+		xml.url = url;
 		xml.send();
 	},
 	


### PR DESCRIPTION
Fix bug: urls containing 404 in the responseURL, but having 404 in the request URL too would be marked as invalid, even if the HTTP status was
200.
Cleanup: remove comment
Improve UI for user: tooltip now says "invalid" instead of "linkInvalid"
For statuses that are undefined, the status is no longer shown in the
tooltip